### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,16 @@ jobs:
             uv pip install -U pip setuptools
             uv pip install .[dev]
       - run:
-          name: 'Integration Tests'
+          name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             uv pip install --upgrade awscli
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
-            run-test --tap=tap-amplitude tests
+
+            source /usr/local/share/virtualenvs/tap-amplitude/bin/activate
+            uv pip install pytest
+            pytest ./tests
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-amplitude/bin/activate
             uv pip install -U pip setuptools
             uv pip install .[dev]
-      - add_ssh_keys
-      - run:
-          name: 'JSON Validator'
-          command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-amplitude/lib/python3.9/site-packages/tap_amplitude/schemas/*.json
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
           name: 'Integration Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install --upgrade awscli
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             run-test --tap=tap-amplitude tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,13 @@ jobs:
             source /usr/local/share/virtualenvs/tap-amplitude/bin/activate
             uv pip install -U pip setuptools
             uv pip install .[dev]
+      - run:
+          name: 'Integration Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            run-test --tap=tap-amplitude tests
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,11 @@ jobs:
             uv pip install -U pip setuptools
             uv pip install .[dev]
       - run:
-          name: 'Unit Tests'
+          name: 'Pylint'
           command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            uv pip install --upgrade awscli
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source dev_env.sh
-
             source /usr/local/share/virtualenvs/tap-amplitude/bin/activate
-            uv pip install pytest
-            pytest ./tests
+            uv pip install pylint
+            pylint -d 'assignment-from-no-return,bad-indentation,broad-exception-raised,consider-using-enumerate,consider-using-f-string,consider-using-from-import,consider-using-in,fixme,line-too-long,missing-function-docstring,missing-module-docstring,unused-import,unused-variable,wrong-import-order' tap_amplitude
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
+    steps:
+      - checkout
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-amplitude
+            source /usr/local/share/virtualenvs/tap-amplitude/bin/activate
+            uv pip install -U pip setuptools
+            uv pip install .[dev]
+      - add_ssh_keys
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-amplitude/lib/python3.9/site-packages/tap_amplitude/schemas/*.json
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: circleci-user


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies