### PR TITLE
SAC-28805: Updated metadata forced-replication-method

### DIFF
--- a/tap_amplitude/__init__.py
+++ b/tap_amplitude/__init__.py
@@ -113,6 +113,7 @@ def discover_catalog(connection):
         md_map = metadata.to_map(create_column_metadata(cols))
         md_map = metadata.write(md_map, (), "table-key-properties", key_properties)
         md_map = metadata.write(md_map, (), "valid-replication-keys", [replication_key] if replication_key else [])
+        md_map = metadata.write(md_map, (), "forced-replication-method", "INCREMENTAL" if replication_key else "FULL_TABLE")
 
         if key_properties:
             for key in key_properties:


### PR DESCRIPTION
# Description of change
This PR added new metadata field `forced-replication-method` field in catalog's metadata.
[SAC-28805](https://qlik-dev.atlassian.net/browse/SAC-28805)

# Manual QA steps
 - [ ]  Discovery: not-tested
 - [ ]  Sync: not-tested
 - [ ]  Unit Tests: not-tested
 - [ ]  Integration test: not-tested
 
# Risks
 - Altering metadata (e.g. replication configuration, rules, filters) could cause unintended tables or columns to be replicated.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
