### PR TITLE
fix-CVE-2026-27459

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+  * Bumped snowflake-connector-python to address vulnerability CVE-2026-27459
+
 ## 1.3.0
   * Added forced-replication-method metadata field [#14](https://github.com/singer-io/tap-amplitude/pull/14)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-amplitude',
-      version='1.3.0',
+      version='1.3.1',
       description='Singer.io tap for extracting data from Amplitude via Snowflake',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-amplitude',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_amplitude'],
       install_requires=[
-          'snowflake-connector-python==3.15.0',
+          'snowflake-connector-python==3.18.0',
           'attrs==25.3.0',
           'pendulum==3.1.0',
           'pytz==2025.2',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-amplitude',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_amplitude'],
       install_requires=[
-          'snowflake-connector-python==3.18.0',
+          'snowflake-connector-python==4.4.0',
           'attrs==25.3.0',
           'pendulum==3.1.0',
           'pytz==2025.2',


### PR DESCRIPTION
# Description of change
Vulnerability CVE-2026-27459 is removed by bumping snowflake-connector-python to use a newer version of pyOpenSSL

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
