### PR TITLE
SAC-30642: Patch Technical Info Disclosure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-amplitude/bin/activate
             uv pip install pylint
-            pylint -d 'assignment-from-no-return,bad-indentation,broad-exception-raised,consider-using-enumerate,consider-using-f-string,consider-using-from-import,consider-using-in,fixme,line-too-long,missing-function-docstring,missing-module-docstring,unused-import,unused-variable,wrong-import-order,too-many-locals' tap_amplitude
+            pylint -d 'assignment-from-no-return,broad-except,broad-exception-caught,broad-exception-raised,chained-comparison,consider-using-f-string,empty-docstring,fixme,invalid-name,line-too-long,logging-fstring-interpolation,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring' tap_amplitude
 workflows:
   version: 2
   commit:

--- a/tap_amplitude/connection.py
+++ b/tap_amplitude/connection.py
@@ -73,7 +73,7 @@ def _patch_user_agent() -> None:
 def _redact_headers(headers: dict) -> dict:
     return {k: (_REDACTED if k in _SENSITIVE_HEADERS else v) for k, v in headers.items()}
 
-
+# pylint: disable=too-many-positional-arguments
 def _patched_handle_unknown_error(self, method, full_url, headers, data, conn) -> None:
     if data:
         _, masked_data, err_str = SecretDetector.mask_secrets(data)
@@ -99,7 +99,7 @@ def _patched_handle_unknown_error(self, method, full_url, headers, data, conn) -
 # Patch 4 – suppress exception telemetry (error msgs + stack traces)
 # ---------------------------------------------------------------------------
 
-def _noop_send_exception_telemetry(self, connection, telemetry_data) -> None:
+def _noop_send_exception_telemetry(self, _connection, _telemetry_data) -> None:
     pass
 
 
@@ -115,9 +115,8 @@ def _noop_log_telemetry_imported_packages(self) -> None:
 # Patch 6 – remove exc_info=True from HTTP-error log line
 # ---------------------------------------------------------------------------
 
-def _patched_log_and_handle_http_error_with_cause(
-    self, e, full_url, method, retry_timeout, retry_count, conn, timed_out=True
-) -> None:
+# pylint: disable=too-many-positional-arguments
+def _patched_log_and_handle_http_error_with_cause(self, e, full_url, _method, _retry_timeout, _retry_count, conn, _timed_out=True) -> None:
     cause = e.args[0]
     _sf_network.logger.error(cause)  # exc_info removed: no file-path traceback
     if isinstance(cause, Error):
@@ -130,7 +129,7 @@ def _patched_log_and_handle_http_error_with_cause(
 # Patch 7 – sanitise raw cause from certificate-error caller-facing message
 # ---------------------------------------------------------------------------
 
-def _patched_handle_invalid_certificate_error(self, conn, full_url, cause) -> None:
+def _patched_handle_invalid_certificate_error(self, conn, _full_url, _cause) -> None:
     Error.errorhandler_wrapper(
         conn, None, OperationalError,
         {
@@ -163,6 +162,7 @@ Auth.base_auth_data = staticmethod(_patched_base_auth_data)             # 1
 _patch_user_agent()                                                     # 2
 SnowflakeRestful._handle_unknown_error = _patched_handle_unknown_error  # 3
 Error.send_exception_telemetry = _noop_send_exception_telemetry         # 4
+#  pylint: disable=protected-access
 SnowflakeConnection._log_telemetry_imported_packages = (                # 5
     _noop_log_telemetry_imported_packages
 )

--- a/tap_amplitude/connection.py
+++ b/tap_amplitude/connection.py
@@ -1,19 +1,197 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
 
 import backoff
 import snowflake.connector
+import snowflake.connector.network as _sf_network
+from snowflake.connector.auth._auth import Auth
+from snowflake.connector.connection import SnowflakeConnection
+from snowflake.connector.errorcode import ER_FAILED_TO_REQUEST
+from snowflake.connector.errors import Error, OperationalError
+from snowflake.connector.network import (
+    HEADER_AUTHORIZATION_KEY,
+    HEADER_EXTERNAL_SESSION_KEY,
+    HTTP_HEADER_USER_AGENT,
+    SnowflakeRestful,
+)
+from snowflake.connector.secret_detector import SecretDetector
+from snowflake.connector.telemetry_oob import TelemetryService
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_REDACTED = "****"
+
+_SENSITIVE_HEADERS: frozenset[str] = frozenset([
+    HEADER_AUTHORIZATION_KEY,     # "Authorization" — session / bearer token
+    HEADER_EXTERNAL_SESSION_KEY,  # "X-Snowflake-External-Session-ID"
+    HTTP_HEADER_USER_AGENT,       # "User-Agent" — contains OS / runtime info
+])
+
+# ---------------------------------------------------------------------------
+# Patch 1 – strip CLIENT_ENVIRONMENT from login request body
+# ---------------------------------------------------------------------------
+
+_original_base_auth_data = Auth.base_auth_data  # plain function in Python 3
+
+
+def _patched_base_auth_data(*args, **kwargs):
+    body = _original_base_auth_data(*args, **kwargs)
+    body.get("data", {}).pop("CLIENT_ENVIRONMENT", None)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Patch 2 – replace system-identifying User-Agent string in all sync modules
+# ---------------------------------------------------------------------------
+
+_SAFE_USER_AGENT = f"PythonConnector/{_sf_network.SNOWFLAKE_CONNECTOR_VERSION}"
+
+_USER_AGENT_MODULE_PATHS = [
+    "snowflake.connector.network",
+    "snowflake.connector.auth._auth",
+    "snowflake.connector.auth.okta",
+    "snowflake.connector.auth.webbrowser",
+    "snowflake.connector.ocsp_snowflake",
+]
+
+
+def _patch_user_agent() -> None:
+    for mod_path in _USER_AGENT_MODULE_PATHS:
+        mod = sys.modules.get(mod_path)
+        if mod is not None and hasattr(mod, "PYTHON_CONNECTOR_USER_AGENT"):
+            setattr(mod, "PYTHON_CONNECTOR_USER_AGENT", _SAFE_USER_AGENT)
+
+
+# ---------------------------------------------------------------------------
+# Patch 3 – redact sensitive headers in _handle_unknown_error log output
+# ---------------------------------------------------------------------------
+
+def _redact_headers(headers: dict) -> dict:
+    return {k: (_REDACTED if k in _SENSITIVE_HEADERS else v) for k, v in headers.items()}
+
+
+def _patched_handle_unknown_error(self, method, full_url, headers, data, conn) -> None:
+    if data:
+        _, masked_data, err_str = SecretDetector.mask_secrets(data)
+        if err_str is None:
+            data = masked_data
+
+    _sf_network.logger.error(
+        "Failed to get the response. Hanging? "
+        "method: %s, url: %s, headers: %s, data: %s",
+        method, full_url, _redact_headers(headers), data,
+    )
+
+    Error.errorhandler_wrapper(
+        conn, None, OperationalError,
+        {
+            "msg": f"Failed to get the response. Hanging? method: {method}, url: {full_url}",
+            "errno": ER_FAILED_TO_REQUEST,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch 4 – suppress exception telemetry (error msgs + stack traces)
+# ---------------------------------------------------------------------------
+
+def _noop_send_exception_telemetry(self, connection, telemetry_data) -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Patch 5 – suppress imported-package list telemetry
+# ---------------------------------------------------------------------------
+
+def _noop_log_telemetry_imported_packages(self) -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Patch 6 – remove exc_info=True from HTTP-error log line
+# ---------------------------------------------------------------------------
+
+def _patched_log_and_handle_http_error_with_cause(
+    self, e, full_url, method, retry_timeout, retry_count, conn, timed_out=True
+) -> None:
+    cause = e.args[0]
+    _sf_network.logger.error(cause)  # exc_info removed: no file-path traceback
+    if isinstance(cause, Error):
+        Error.errorhandler_wrapper_from_cause(conn, cause)
+    else:
+        self.handle_invalid_certificate_error(conn, full_url, cause)
+
+
+# ---------------------------------------------------------------------------
+# Patch 7 – sanitise raw cause from certificate-error caller-facing message
+# ---------------------------------------------------------------------------
+
+def _patched_handle_invalid_certificate_error(self, conn, full_url, cause) -> None:
+    Error.errorhandler_wrapper(
+        conn, None, OperationalError,
+        {
+            "msg": "Failed to execute request: certificate or SSL error (details suppressed)",
+            "errno": ER_FAILED_TO_REQUEST,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch 8 – neuter OOB telemetry context (account, host, user, warehouse …)
+# ---------------------------------------------------------------------------
+
+def _noop_update_context(self, connection_params) -> None:
+    """Prevent connection parameters from being stored as OOB telemetry tags."""
+    self.configure_deployment(connection_params)
+    self.context = {}
+
+
+def _noop_get_connection_string(self) -> str:
+    """Prevent host:port from appearing in OOB telemetry tags."""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Apply all patches at import time, before any connection is created
+# ---------------------------------------------------------------------------
+
+Auth.base_auth_data = staticmethod(_patched_base_auth_data)             # 1
+_patch_user_agent()                                                     # 2
+SnowflakeRestful._handle_unknown_error = _patched_handle_unknown_error  # 3
+Error.send_exception_telemetry = _noop_send_exception_telemetry         # 4
+SnowflakeConnection._log_telemetry_imported_packages = (                # 5
+    _noop_log_telemetry_imported_packages
+)
+SnowflakeRestful.log_and_handle_http_error_with_cause = (               # 6
+    _patched_log_and_handle_http_error_with_cause
+)
+SnowflakeRestful.handle_invalid_certificate_error = (                   # 7
+    _patched_handle_invalid_certificate_error
+)
+TelemetryService.update_context = _noop_update_context                  # 8
+TelemetryService.get_connection_string = _noop_get_connection_string    # 8
+
+# ---------------------------------------------------------------------------
+# Connection
+# ---------------------------------------------------------------------------
 
 
 @backoff.on_exception(backoff.expo,
                       (snowflake.connector.Error),
                       max_tries=5,
                       factor=2)
-
-
 def connect_with_backoff(config):
-  return snowflake.connector.connect(user=config['username'],
-    password=config['password'],
-    account=config['account'],
-    database=config['database'],
-    warehouse=config['warehouse']
-  )
+    return snowflake.connector.connect(
+        user=config['username'],
+        password=config['password'],
+        account=config['account'],
+        database=config['database'],
+        warehouse=config['warehouse'],
+        # Prevent the full sys.modules list from being sent in telemetry even
+        # if _log_telemetry_imported_packages is somehow invoked.
+        log_imported_packages_in_telemetry=False,
+    )


### PR DESCRIPTION
# Description of change
Co-Pilot Summary:

```
Snowflake connection helper with monkey-patches that prevent sensitive and
system-identifying information from leaking in outbound request headers,
request bodies, telemetry payloads, and log output.

Patches applied (all at import time, before any connection is made):

1. CLIENT_ENVIRONMENT stripped from login request body.
   Auth.base_auth_data includes OS name/version, Python runtime/version/
   compiler, application binary path, and platform-probe results under the
   CLIENT_ENVIRONMENT key.  The key is removed before the body is sent.

2. System-identifying User-Agent header replaced.
   PYTHON_CONNECTOR_USER_AGENT has the form:
       PythonConnector/<ver> (<os-platform>) <impl>/<python-ver>
   Every sync module that binds this constant by name is patched to use
   "PythonConnector/<ver>" instead, removing OS and runtime details.

3. Sensitive headers redacted in error-log output.
   SnowflakeRestful._handle_unknown_error logged the full headers dict
   (Authorization token, X-Snowflake-External-Session-ID, User-Agent) on
   request failure.  The replacement redacts those values to "****".

4. Exception telemetry suppressed.
   Error.send_exception_telemetry would transmit error messages (which may
   embed account name, host, or other context) and filtered stack traces
   over the in-band telemetry channel when the server enables it.
   The method is replaced with a no-op.

5. Imported-package list never sent.
   SnowflakeConnection._log_telemetry_imported_packages sends the full
   sys.modules key set (every installed package name) via in-band telemetry.
   The method is replaced with a no-op, and log_imported_packages_in_telemetry
   is also set to False in connect() as a belt-and-suspenders measure.

6. Traceback suppressed from HTTP-error log lines.
   SnowflakeRestful.log_and_handle_http_error_with_cause called
   logger.error(cause, exc_info=True), appending a full Python traceback
   (with local file paths) to the log.  exc_info is removed.

7. Raw exception cause sanitised in certificate-error messages.
   SnowflakeRestful.handle_invalid_certificate_error embedded the raw
   exception cause (which can contain host names, cert paths, SSL details)
   in the caller-facing OperationalError message.  A generic message is
   used instead.

8. OOB telemetry context neutered.
   TelemetryService.update_context stored all connection parameters (account,
   user, host, warehouse, database, protocol, port) as ctx_* tags on every
   out-of-band event; get_connection_string() exposed the full host:port URL.
   Both are replaced with no-ops so no connection details ever appear in OOB
   telemetry payloads.
   ```

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
